### PR TITLE
Add meta referrer tag

### DIFF
--- a/themes/hugo-future-imperfect/layouts/partials/header.html
+++ b/themes/hugo-future-imperfect/layouts/partials/header.html
@@ -18,6 +18,7 @@
 
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="referrer" content="always" />
         {{ .Hugo.Generator }}
         {{ partial "favicon" . }}
 


### PR DESCRIPTION
Referrer helps marketers and webmasters to see exactly where their traffic is coming from.
We should track this information always.

More at https://moz.com/blog/meta-referrer-tag