### PR TITLE
Fix careers link

### DIFF
--- a/content/ita/careers.md
+++ b/content/ita/careers.md
@@ -25,4 +25,4 @@ twitterlargeimage: "/images/careers/banner.png"
  * Convenzioni (bar, ristoranti, palestre e molto altro), Ticket Restaurant, caffè, acqua e frutta fresca ogni giorno
  * Fare il lavoro che ami in una realtà italiana di successo con un top team al tuo fianco
 
-Se sei interessato, dai uno sguardo alle nostre {{< url-link "offerte di lavoro »" "https://jobs.facile.it/chi-cerchiamo.html" "_blank">}}.
+Se sei interessato, dai uno sguardo alle nostre {{< url-link "offerte di lavoro »" "https://facile.jobs.personio.de/#department-538752" "_blank">}}.


### PR DESCRIPTION
Current link to careers page in https://engineering.facile.it/ita/careers/ is broken, this replaces the old link with new one that directs to tech department careers page on Personio